### PR TITLE
Support dump restore coefficient

### DIFF
--- a/mrblib/ChangeFinder/SDAR.rb
+++ b/mrblib/ChangeFinder/SDAR.rb
@@ -14,6 +14,19 @@ class ChangeFinder
       @c = (0..@term - 1).map { |i| rand }
     end
 
+    def dump
+      {:r => @r, :mu => @mu, :term => @term, :data => @data, :sigma => @sigma, :c => @c}
+    end
+
+    def restore params
+      @r = params[:r]
+      @mu = params[:me]
+      @term = params[:term]
+      @data = params[:data]
+      @sigma = params[:sigma]
+      @c = params[:c]
+    end
+
     def next x
       len = @data.size
       @mu = (1 - @r) * @mu + @r * x

--- a/test/mrb_changefinder.rb
+++ b/test/mrb_changefinder.rb
@@ -15,6 +15,21 @@ assert "ChangeFinder::SDAR#score" do
   assert_equal 0.69314718055995, ChangeFinder::SDAR.new(3, 0.1).score(0.5).round(14)
 end
 
+assert 'ChangeFinder::SDAR#{dump, restore}' do
+  cf = ChangeFinder::SDAR.new(3, 0.1)
+  cf.score(0.5)
+  d = cf.dump
+  score = cf.score(0.1)
+
+  cf_dump = ChangeFinder::SDAR.new(3, 0.1)
+  cf_dump.restore d
+
+  score_dump = cf_dump.score(0.1)
+
+  assert_equal 2.302585092994, score.round(13)
+  assert_equal score, score_dump
+end
+
 # ChangeFinder::Utils class
 assert "ChangeFinder::Utils.smooth" do
   assert_equal 2, ChangeFinder::Utils.smooth([1,2,3], 3)


### PR DESCRIPTION
``` ruby
assert 'ChangeFinder::SDAR#{dump, restore}' do
  cf = ChangeFinder::SDAR.new(3, 0.1)
  cf.score(0.5)

  ## dump current sdar coefficient
  d = cf.dump

  score = cf.score(0.1)

  cf_dump = ChangeFinder::SDAR.new(3, 0.1)

  ## restore sdar coefficient from dump data
  cf_dump.restore d

  score_dump = cf_dump.score(0.1)

  assert_equal 2.302585092994, score.round(13)
  assert_equal score, score_dump
end
```
