### PR TITLE
Remove SDAR.rb irrelevant statement

### DIFF
--- a/mrblib/ChangeFinder/SDAR.rb
+++ b/mrblib/ChangeFinder/SDAR.rb
@@ -31,8 +31,6 @@ class ChangeFinder
       len = @data.size
       @mu = (1 - @r) * @mu + @r * x
 
-      c = @sigma
-
       (0..(@term - 1)).each do |j|
         @c[j] = (1 - @r) * @c[j] + @r * (x - @mu) * (@data[len - 1 - j] - @mu) if @data[len - 1 - j]
       end


### PR DESCRIPTION
The assignment statement of `c = @sigma` is irrelevant because:

* The left-side local variable `c` is assigned as `@sigma`
* The local variable `c` is unused in the method `ChangeFinder.SDAR#next`
* The Rake tests passed without error by removing this statement